### PR TITLE
JNG-4762 Add checksum regeneration feature to support code formatters

### DIFF
--- a/src/main/java/hu/blackbelt/judo/generator/commons/ModelGenerator.java
+++ b/src/main/java/hu/blackbelt/judo/generator/commons/ModelGenerator.java
@@ -192,6 +192,24 @@ public class ModelGenerator<M> {
         writeGeneratedFiles(targetDirectory, generatorFileEntryCollection, generatorFilesName);
     }
 
+
+    public static <D> Consumer<Map.Entry<D, Collection<GeneratedFile>>> getChecksumCalculatorForActor(
+            Function<D, File> actorTypeTargetDirectoryResolver,
+            Function<D, String> actorTypeNameResolver,  Log log) {
+        return e -> writeDirectory(e.getValue(), actorTypeTargetDirectoryResolver.apply(e.getKey()), GENERATED_FILES + "-" + actorTypeNameResolver.apply(e.getKey()));
+
+    }
+
+    public static Consumer<Collection<GeneratedFile>> getChecksumCalculator(Supplier<File> targetDirectoryResolver, Log log) {
+        return e -> recalculateChucksumForDirectory(targetDirectoryResolver.get(), GENERATED_FILES);
+    }
+
+    public static void recalculateChucksumForDirectory(File targetDirectory, String generatorFilesName) {
+        Collection<GeneratorFileEntry> savedFileEntryCollection = readGeneratedFiles(targetDirectory, generatorFilesName);
+        Collection<GeneratorFileEntry> filesystemFileEntryCollection = readFilesystemEntries(targetDirectory, savedFileEntryCollection);
+        writeGeneratedFiles(targetDirectory, filesystemFileEntryCollection, generatorFilesName);
+    }
+
     public static List<GeneratorFileEntry> getGeneratorFiles(Collection<GeneratedFile> generatedFiles) {
         ArrayList<GeneratorFileEntry> result = new ArrayList();
         result.addAll(generatedFiles.stream().map(

--- a/src/test/java/hu/blackbelt/judo/generator/commons/ModelGeneratorTest.java
+++ b/src/test/java/hu/blackbelt/judo/generator/commons/ModelGeneratorTest.java
@@ -120,7 +120,7 @@ public class ModelGeneratorTest {
         assertThrows(IllegalStateException.class, () ->
                 ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES));
 
-        ModelGenerator.recalculateChucksumForDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
+        ModelGenerator.recalculateChecksumToDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
 
         ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
     }

--- a/src/test/java/hu/blackbelt/judo/generator/commons/ModelGeneratorTest.java
+++ b/src/test/java/hu/blackbelt/judo/generator/commons/ModelGeneratorTest.java
@@ -111,6 +111,21 @@ public class ModelGeneratorTest {
     }
 
     @Test
+    void testChecksumRegeneration() throws IOException {
+        ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
+
+        Path file1 = absolutePathFor("level1", "file1");
+        Files.write(file1, "level1/file1Modified".getBytes(StandardCharsets.UTF_8));
+
+        assertThrows(IllegalStateException.class, () ->
+                ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES));
+
+        ModelGenerator.recalculateChucksumForDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
+
+        ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
+    }
+
+    @Test
     void testGeneratedFileChanges() throws IOException {
         ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4762" title="JNG-4762" target="_blank"><img alt="Task" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />JNG-4762</a>  Extract checksum generation as separate step to avoid checksum errors on autotoformat
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-4762 Add checksum regeneration feature to support code formatters