### PR TITLE
JNG-5932 Fixing reset chesksum / generation workflow regressions

### DIFF
--- a/src/main/java/hu/blackbelt/judo/generator/commons/GeneratorFileEntry.java
+++ b/src/main/java/hu/blackbelt/judo/generator/commons/GeneratorFileEntry.java
@@ -33,17 +33,18 @@ public final class GeneratorFileEntry implements Comparable {
     @NonNull
     String path;
 
-    @NonNull
     String checksum;
 
     public static GeneratorFileEntry fromString(String str) {
         String[] parts = str.split(",");
-        if (parts.length != 2) {
-            throw new IllegalArgumentException("Could not parse file entry: " + str);
+        String name = parts[0];
+        String checksum = "";
+        if (parts.length == 2) {
+            checksum = parts[1];
         }
         return GeneratorFileEntry.generatorFileEntry()
-                .path(parts[0])
-                .checksum(parts[1])
+                .path(name)
+                .checksum(checksum)
                 .build();
     }
 

--- a/src/main/java/hu/blackbelt/judo/generator/commons/ModelGenerator.java
+++ b/src/main/java/hu/blackbelt/judo/generator/commons/ModelGenerator.java
@@ -179,7 +179,7 @@ public class ModelGenerator<M> {
             List<GeneratorFileEntry> checksumMismatchInFilesystem = filesystemFileEntryCollection.stream()
                     .filter(f -> savedFileEntryMap.containsKey(f.getPath()))
                     .filter(f -> !checksumIgnore.shouldExcludeFile(new File(targetDirectory, f.getPath()).toPath()))
-                    .filter(f -> !f.getChecksum().equals(savedFileEntryMap.get(f.getPath()).getChecksum()))
+                    .filter(f -> !"".equals(f.getChecksum()) && !f.getChecksum().equals(savedFileEntryMap.get(f.getPath()).getChecksum()))
                     .filter(f -> !generatorIgnore.shouldExcludeFile(new File(targetDirectory, f.getPath()).toPath()))
                     .collect(Collectors.toList());
 
@@ -213,12 +213,11 @@ public class ModelGenerator<M> {
     public static <D> Consumer<D> getDirectoryChecksumRemoverForActor(
             Function<D, File> actorTypeTargetDirectoryResolver,
             Function<D, String> actorTypeNameResolver) {
-        return e -> deleteExitingFileInDirectory(actorTypeTargetDirectoryResolver.apply(e), GENERATED_FILES + "-" + actorTypeNameResolver.apply(e));
-
+        return e -> resetGeneratedFilesChecksum(actorTypeTargetDirectoryResolver.apply(e), GENERATED_FILES + "-" + actorTypeNameResolver.apply(e));
     }
 
     public static Runnable getDirectoryChecksumRemover(Supplier<File> targetDirectoryResolver) {
-        return () -> deleteExitingFileInDirectory(targetDirectoryResolver.get(), GENERATED_FILES);
+        return () -> resetGeneratedFilesChecksum(targetDirectoryResolver.get(), GENERATED_FILES);
     }
 
     /*
@@ -236,13 +235,13 @@ public class ModelGenerator<M> {
 
     public static <D> Consumer<D> getDirectoryGitignoreSynchronizerForActor(
             Function<D, File> actorTypeTargetDirectoryResolver,
-            Function<D, String> actorTypeNameResolver) {
-        return e -> synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(actorTypeTargetDirectoryResolver.apply(e), GENERATED_FILES + "-" + actorTypeNameResolver.apply(e));
+            Function<D, String> actorTypeNameResolver, Function<String, Boolean> fileIsIgnored) {
+        return e -> synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(actorTypeTargetDirectoryResolver.apply(e), GENERATED_FILES + "-" + actorTypeNameResolver.apply(e), fileIsIgnored);
 
     }
 
-    public static Runnable getDirectoryGitignoreSynchronizer(Supplier<File> targetDirectoryResolver) {
-        return () -> synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(targetDirectoryResolver.get(), GENERATED_FILES);
+    public static Runnable getDirectoryGitignoreSynchronizer(Supplier<File> targetDirectoryResolver, Function<String, Boolean> fileIsIgnored) {
+        return () -> synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(targetDirectoryResolver.get(), GENERATED_FILES, fileIsIgnored);
     }
 
 
@@ -273,9 +272,10 @@ public class ModelGenerator<M> {
                 });
     }
 
-    public static void synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(File targetDirectory, String generatorFilesName) {
+    public static void synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(File targetDirectory, String generatorFilesName, Function<String, Boolean> fileIsIgnored) {
         GitIgnoreSynchronizer gitIgnoreSynchronizer = new GitIgnoreSynchronizer(targetDirectory.toPath());
-        gitIgnoreSynchronizer.addGeneratedFiles(readGeneratedFiles(targetDirectory, generatorFilesName));
+        gitIgnoreSynchronizer.addGeneratedFiles(readGeneratedFiles(targetDirectory, generatorFilesName)
+                .stream().filter(e -> !fileIsIgnored.apply(e.getPath())).toList());
     }
 
     public static void deleteExitingFileInDirectory(File targetDirectory, String generatorFilesName) {
@@ -332,6 +332,14 @@ public class ModelGenerator<M> {
             log.error("Could not write file: " + outFile.getAbsolutePath());
             throw new RuntimeException(exception);
         }
+    }
+
+    public static void resetGeneratedFilesChecksum(File targetDirectory, String generatedFileName) {
+        Collection<GeneratorFileEntry> savedFileEntryCollection = readGeneratedFiles(targetDirectory, generatedFileName);
+        savedFileEntryCollection.forEach(s -> {
+            s.setChecksum("");
+        });
+        writeGeneratedFiles(targetDirectory, savedFileEntryCollection, generatedFileName);
     }
 
     public static void writeGeneratedFiles(File targetDirectory, Collection<GeneratorFileEntry> generatorFileEntryCollection, String generatedFileName) {
@@ -471,11 +479,11 @@ public class ModelGenerator<M> {
                 parameter.getDiscriminatorTargetNameResolver());
     }
 
-    public static <T> void synchronizeGitignoreInDirectory(GeneratorParameter<T> parameter, Collection<T> discriminators) throws Exception {
+    public static <T> void synchronizeGitignoreInDirectory(GeneratorParameter<T> parameter, Collection<T> discriminators, Function<String, Boolean> fileIsIgnored) throws Exception {
         discriminators.forEach(getDirectoryGitignoreSynchronizerForActor(
                 parameter.getDiscriminatorTargetDirectoryResolver(),
-                parameter.getDiscriminatorTargetNameResolver()));
-        getDirectoryGitignoreSynchronizer(parameter.targetDirectoryResolver).run();
+                parameter.getDiscriminatorTargetNameResolver(), fileIsIgnored));
+        getDirectoryGitignoreSynchronizer(parameter.targetDirectoryResolver, fileIsIgnored).run();
     }
 
     public static <T> void recalculateChecksumToDirectory(GeneratorParameter<T> parameter, Collection<T> discriminators) {

--- a/src/test/java/hu/blackbelt/judo/generator/commons/ModelGeneratorTest.java
+++ b/src/test/java/hu/blackbelt/judo/generator/commons/ModelGeneratorTest.java
@@ -167,7 +167,7 @@ public class ModelGeneratorTest {
         Files.write(checksumIgnoreFile, "level1/file1".getBytes(StandardCharsets.UTF_8));
         ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES, true);
 
-        ModelGenerator.synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
+        ModelGenerator.synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES, t -> false);
 
         assertEquals("# JUDO GENERATOR BLOCK START|level1/file1|level1/file2|level1/level2/file3|# JUDO GENERATOR BLOCK END", Files.readAllLines(gitIgnore).stream().collect(Collectors.joining("|")));
 
@@ -186,7 +186,7 @@ public class ModelGeneratorTest {
         Files.write(checksumIgnoreFile, "level1/file1".getBytes(StandardCharsets.UTF_8));
         ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES, true);
 
-        ModelGenerator.synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
+        ModelGenerator.synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES, f -> false);
 
         assertEquals("SOME OTHER FILE|# JUDO GENERATOR BLOCK START|level1/file1|level1/file2|level1/level2/file3|# JUDO GENERATOR BLOCK END", Files.readAllLines(gitIgnore).stream().collect(Collectors.joining("|")));
 
@@ -206,7 +206,7 @@ public class ModelGeneratorTest {
         Files.write(checksumIgnoreFile, "level1/file1".getBytes(StandardCharsets.UTF_8));
         ModelGenerator.writeDirectory(generatedFileCollecton, tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES, true);
 
-        ModelGenerator.synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES);
+        ModelGenerator.synchronizeGeneratorIgnoredFileWithGitignoreInDirectory(tmpTargetDir.toFile(), ModelGenerator.GENERATED_FILES, f -> false);
 
         assertEquals("SOME OTHER FILE|# JUDO GENERATOR BLOCK START|level1/file1|level1/file2|level1/level2/file3|# JUDO GENERATOR BLOCK END|after|another|lines", Files.readAllLines(gitIgnore).stream().collect(Collectors.joining("|")));
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5932" title="JNG-5932" target="_blank"><img alt="Story" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />JNG-5932</a>  Add gitignore synchronized generation workflow to ESM full template.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
